### PR TITLE
Enable GitHub Actions

### DIFF
--- a/.github/jira-mapping-rules.yml
+++ b/.github/jira-mapping-rules.yml
@@ -1,0 +1,11 @@
+defaultJiraIssueType: 10009
+rules:
+  - type: label
+    labels:
+      - bug
+    jiraIssueType: 10011
+  - type: title
+    searchTerms:
+      - feature
+      - epic
+    jiraIssueType: 10000

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,12 @@
+on:
+  push:
+    branches:
+    tags:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Maven Build
+    uses: telicent-oss/shared-workflows/.github/workflows/maven.yml@maven-workflow
+    secrets: inherit
+

--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -1,0 +1,21 @@
+name: Sync with JIRA
+
+on:
+  workflow_dispatch: 
+  issues: 
+    types:
+      - opened
+      - edited
+      - transferred
+      - reopened
+
+jobs:
+  sync-to-jira:
+    uses: telicent-oss/shared-workflows/.github/workflows/jira-sync.yml@jira-sync
+    with:
+      jira-url: https://telicent.atlassian.net
+      jira-project: TELPLAT
+      issue-mapping-file: .github/jira-mapping-rules.yml
+    secrets: inherit
+
+  


### PR DESCRIPTION
Adds a workflow for performing Maven Builds and a dogfooding workflow of using the jira-sync tool upon itself