### PR TITLE
Adds comment sync support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ issues where appropriate and only create new JIRA issues where one doesn't yet e
 As noted if you keep this file around somewhere then there is no need to run this step every time, you can just supply
 the file to [Step 3](#step-3) and it automatically keeps it up to date as it sync's new issues.
 
-### Step 2
+### Step 2
 
 In order for the tool to know what type of JIRA issues to create you need to establish some mapping rules that tell it
 how a GitHub issue should be mapped into a JIRA issue.  The first stage of this is to run the `jira-sync issues
@@ -228,16 +228,55 @@ issue in question e.g. `--github-issue-id 123` would sync only Issue 123 from yo
 
 # FAQs
 
+## Which GitHub issues get sync'd to JIRA?
+
+It depends on the option provided, as shown in [Step 3](#step-3).  The default behaviour is to sync all open issues in
+the provided repository.
+
+You can specify `--include-closed` to force the sync of closed issues as well.
+
+Alternatively you can sync a single issue by supplying the `--github-issue-id` option.  If this issue is already closed then you will need to use `--include-closed` as well.
+
+## Can I check what the tool will do ahead of time?
+
+Yes, the `to-jira` command includes a `--dry-run` option.  When specified this will simply print what would have
+occurred without actually doing it.  Note that some read interactions with GitHub and JIRA still occur in this mode but no write actions happen.
+
+Note that in this mode the JIRA Keys assigned to issues will not be known so you will see example values like `YOURPROJECT-?` instead of `YOURPROJECT-123`.
+
 ## What gets sync'd to JIRA?
 
-Currently the title and the content of a GitHub issue gets sync'd across to JIRA.  The title will populate the Summary
-field of the issue, and the content the description field.  The tool uses some of Atlassian's newer tooling to attempt
-to convert Markdown in the GitHub content into richly formatted text in JIRA, **but** not all Markdown syntax translates
-so you **MAY** see some weird formatting.
+Currently the title, content and labels of a GitHub issue gets sync'd across to JIRA.  The title will populate the
+Summary field of the issue, and the content the description field.  Since JIRA labels are simple strings the GitHub
+label names are used to populate the list of JIRA labels.
 
-The assignee/reporter of an issue is not sync'd, nor are any GitHub labels, GitHub comments etc.  Also if a GitHub issue
-transitions, i.e. closes, the corresponding JIRA does not transition currently.  All these things **MAY** be supported
-in the future subject to demand.
+Optionally, if the `--include-comments` option is specified, then the content of comments are also sync'd across as JIRA
+comments on the corresponding JIRA issue.
+
+Optionally, if the `--jira-repository-field` option is supplied with a JIRA Field ID then the corresponding JIRA issue
+field will be populated with a reference to the GitHub repository e.g. `telicent-oss/jira-sync`.
+
+Since the [user](#whose-jiragithub-credentials-should-i-used) running the sync tool is likely not the author of the
+issues and comments being sync'd across all content will be prefaced with the following:
+
+> GitHub User [Rob Vesse](https://github.com/rvesse) [filed an issue](https://github.com/telicent-oss/jira-sync/issues/1)
+> on 2024-02-26T11:23:39Z and was last updated on 2024-04-22T09:18:50Z
+
+This allows seeing who actually created an issue/comment, and easily discovering the original author and content if
+needed.
+
+The tool uses some of Atlassian's newer libraries to automatically convert Markdown in the GitHub content into richly
+formatted text in JIRA, **but** not all Markdown syntax translates so you **MAY** see some weird formatting on some
+content.
+
+# What isn't sync'd to JIRA?
+
+The assignee/reporter of an issue is not sync'd, primarily because a GitHub repository may have a very different set of
+users to your JIRA instance.
+
+Also if a GitHub issue transitions, i.e. closes, the corresponding JIRA does not transition currently.  
+
+These things **MAY** be supported in the future subject to demand.
 
 ## Are issues always updated?
 
@@ -257,13 +296,14 @@ reporter field.
 If you are only running this tool locally then store it locally.
 
 If you are automating the running of this tool, e.g. on CI/CD infrastructure, then store it somewhere persistent and
-read and write it before and after the build.
+read and write it before and after the build.  You can always [recompute](#what-if-i-lose-my-cross-links-file) it as
+needed based on the metadata
 
 ## What if I lose my cross links file?
 
-The tool takes advantage of internal metadata for JIRA remote links to allow it to detect the links it has previously
-created during sync operations.  Provided JIRA users are not removing those links or modifying them this allows the
-information to be recovered.
+The tool takes advantage of internal metadata for JIRA remote links and comments to allow it to detect the JIRA content
+it has previously created during sync operations.  Provided JIRA users are not removing this metadata or modifying them
+this information can be recovered.
 
 Therefore, you can always use the command shown in [Step 1](#step-1) to recreate a lost cross links file if necessary.
 

--- a/src/main/java/io/telicent/jira/sync/GitHubToJiraSync.java
+++ b/src/main/java/io/telicent/jira/sync/GitHubToJiraSync.java
@@ -1,4 +1,0 @@
-package io.telicent.jira.sync;
-
-public class GitHubToJiraSync {
-}

--- a/src/main/java/io/telicent/jira/sync/cli/JiraSyncCli.java
+++ b/src/main/java/io/telicent/jira/sync/cli/JiraSyncCli.java
@@ -8,6 +8,7 @@ import com.github.rvesse.airline.parser.ParseResult;
 import com.github.rvesse.airline.parser.errors.ParseException;
 import com.github.rvesse.airline.parser.errors.handlers.CollectAll;
 import io.telicent.jira.sync.cli.commands.*;
+import io.telicent.jira.sync.cli.commands.issues.*;
 
 //@formatter:off
 @Cli(name = "jira-sync",
@@ -20,11 +21,14 @@ import io.telicent.jira.sync.cli.commands.*;
         @Group(
             name = "issues",
             commands = {
+                Comments.class,
                 ComputeCrossLinks.class,
+                Fields.class,
                 IssueTypes.class,
                 GitHubToJira.class,
                 RemoteLinks.class
-            }
+            },
+            defaultCommand = Help.class
         )
      },
      parserConfiguration = @Parser(errorHandler = CollectAll.class))

--- a/src/main/java/io/telicent/jira/sync/cli/commands/JiraGitHubSyncCommand.java
+++ b/src/main/java/io/telicent/jira/sync/cli/commands/JiraGitHubSyncCommand.java
@@ -3,7 +3,7 @@ package io.telicent.jira.sync.cli.commands;
 import com.github.rvesse.airline.annotations.AirlineModule;
 import io.telicent.jira.sync.cli.options.GitHubOptions;
 
-public abstract class JiraGitHubSyncCommand extends JiraSyncCommand {
+public abstract class JiraGitHubSyncCommand extends JiraProjectSyncCommand {
 
     @AirlineModule
     protected final GitHubOptions gitHubOptions = new GitHubOptions();

--- a/src/main/java/io/telicent/jira/sync/cli/commands/JiraProjectSyncCommand.java
+++ b/src/main/java/io/telicent/jira/sync/cli/commands/JiraProjectSyncCommand.java
@@ -1,0 +1,32 @@
+package io.telicent.jira.sync.cli.commands;
+
+import com.atlassian.jira.rest.client.api.RestClientException;
+import com.github.rvesse.airline.annotations.AirlineModule;
+import io.telicent.jira.sync.cli.options.JiraProjectOptions;
+import org.apache.commons.lang3.StringUtils;
+
+
+public abstract class JiraProjectSyncCommand extends SyncCommand {
+
+    @AirlineModule
+    protected JiraProjectOptions jiraOptions = new JiraProjectOptions();
+
+    protected void reportJiraRestError(RestClientException e) {
+        if (e.getErrorCollections()
+             .stream()
+             .flatMap(c -> c.getErrorMessages().stream())
+             .anyMatch(m -> StringUtils.containsIgnoreCase(m,
+                                                           "'" + this.jiraOptions.getProjectKey() + "' does not exist"))) {
+            System.out.println(this.jiraOptions.getProjectKey() + " does not appear to be a valid JIRA Project Key");
+            System.out.println(
+                    "NB: This error may occur if you are computing links for a JIRA Project that the provided JIRA Credentials do not have access to");
+        } else {
+            System.out.println(
+                    "Failed to complete a JIRA REST API call against JIRA Project " + this.jiraOptions.getProjectKey());
+            e.getErrorCollections()
+             .stream()
+             .flatMap(c -> c.getErrorMessages().stream())
+             .forEach(m -> System.out.println("  " + m));
+        }
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/cli/commands/JiraSyncCommand.java
+++ b/src/main/java/io/telicent/jira/sync/cli/commands/JiraSyncCommand.java
@@ -3,6 +3,7 @@ package io.telicent.jira.sync.cli.commands;
 import com.atlassian.jira.rest.client.api.RestClientException;
 import com.github.rvesse.airline.annotations.AirlineModule;
 import io.telicent.jira.sync.cli.options.JiraOptions;
+import io.telicent.jira.sync.cli.options.JiraProjectOptions;
 import org.apache.commons.lang3.StringUtils;
 
 
@@ -12,22 +13,10 @@ public abstract class JiraSyncCommand extends SyncCommand {
     protected JiraOptions jiraOptions = new JiraOptions();
 
     protected void reportJiraRestError(RestClientException e) {
-        if (e.getErrorCollections()
-             .stream()
-             .flatMap(c -> c.getErrorMessages().stream())
-             .anyMatch(m -> StringUtils.containsIgnoreCase(m,
-                                                           "'" + this.jiraOptions.getProjectKey() + "' does not exist"))) {
-            System.out.println(
-                    this.jiraOptions.getProjectKey() + " does not appear to be a valid JIRA Project Key");
-            System.out.println(
-                    "NB: This error may occur if you are computing links for a JIRA Project that the provided JIRA Credentials do not have access to");
-        } else {
-            System.out.println(
-                    "Failed to search for issues in JIRA Project " + this.jiraOptions.getProjectKey());
-            e.getErrorCollections()
-             .stream()
-             .flatMap(c -> c.getErrorMessages().stream())
-             .forEach(m -> System.out.println("  " + m));
-        }
+        System.out.println("Failed to complete a JIRA REST API call:");
+        e.getErrorCollections()
+         .stream()
+         .flatMap(c -> c.getErrorMessages().stream())
+         .forEach(m -> System.out.println("  " + m));
     }
 }

--- a/src/main/java/io/telicent/jira/sync/cli/commands/issues/Comments.java
+++ b/src/main/java/io/telicent/jira/sync/cli/commands/issues/Comments.java
@@ -1,0 +1,46 @@
+package io.telicent.jira.sync.cli.commands.issues;
+
+import com.atlassian.jira.rest.client.api.RestClientException;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Required;
+import io.atlassian.util.concurrent.Promise;
+import io.telicent.jira.sync.cli.commands.JiraSyncCommand;
+import io.telicent.jira.sync.client.AsynchronousIssueCommentsClient;
+import io.telicent.jira.sync.client.EnhancedJiraRestClient;
+import io.telicent.jira.sync.client.model.Comment;
+
+import java.io.IOException;
+
+@Command(name = "jira-comments")
+public class Comments extends JiraSyncCommand {
+
+    @Option(name = { "--jira-issue", "--jira-issue-id", "--jira-issue-key" }, title = "JiraIssueKey", description = "Specifies the key for a specific JIRA Issue that this command should operate over e.g. EXAMPLE-1234")
+    @Required
+    private String issueKey;
+
+    @Override
+    public int run() {
+        try (EnhancedJiraRestClient jira = this.jiraOptions.connect()) {
+            AsynchronousIssueCommentsClient commentsClient = jira.getCommentsClient();
+
+            Promise<Iterable<Comment>> commentsPromise = commentsClient.getComments(this.issueKey);
+            Iterable<Comment> comments = commentsPromise.claim();
+
+            for (Comment comment : comments) {
+                System.out.println("Author: " + comment.getAuthor().getDisplayName());
+                System.out.println("Created: " + comment.getCreationDate());
+                System.out.println("Body: ");
+                System.out.println(comment.getBodyDocument().toPlainText());
+                System.out.println();
+            }
+
+            return 0;
+        } catch (RestClientException e) {
+            this.reportJiraRestError(e);
+            return 1;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/cli/commands/issues/Comments.java
+++ b/src/main/java/io/telicent/jira/sync/cli/commands/issues/Comments.java
@@ -9,13 +9,17 @@ import io.telicent.jira.sync.cli.commands.JiraSyncCommand;
 import io.telicent.jira.sync.client.AsynchronousIssueCommentsClient;
 import io.telicent.jira.sync.client.EnhancedJiraRestClient;
 import io.telicent.jira.sync.client.model.Comment;
+import org.apache.commons.collections4.IterableUtils;
 
 import java.io.IOException;
+import java.util.stream.Collectors;
 
 @Command(name = "jira-comments")
 public class Comments extends JiraSyncCommand {
 
-    @Option(name = { "--jira-issue", "--jira-issue-id", "--jira-issue-key" }, title = "JiraIssueKey", description = "Specifies the key for a specific JIRA Issue that this command should operate over e.g. EXAMPLE-1234")
+    @Option(name = {
+            "--jira-issue", "--jira-issue-id", "--jira-issue-key"
+    }, title = "JiraIssueKey", description = "Specifies the key for a specific JIRA Issue that this command should operate over e.g. EXAMPLE-1234")
     @Required
     private String issueKey;
 
@@ -27,11 +31,19 @@ public class Comments extends JiraSyncCommand {
             Promise<Iterable<Comment>> commentsPromise = commentsClient.getComments(this.issueKey);
             Iterable<Comment> comments = commentsPromise.claim();
 
+            Promise<Iterable<Comment>> commentsByIdPromise = commentsClient.getCommentsByIds(
+                    IterableUtils.toList(comments).stream().map(c -> c.getId().toString()).toList());
+            comments = commentsByIdPromise.claim();
+
             for (Comment comment : comments) {
                 System.out.println("Author: " + comment.getAuthor().getDisplayName());
                 System.out.println("Created: " + comment.getCreationDate());
                 System.out.println("Body: ");
                 System.out.println(comment.getBodyDocument().toPlainText());
+                if (comment.getProperties() != null) {
+                    System.out.println("Has Properties: ");
+                    comment.getProperties().stream().forEach(p -> System.out.println("  " + p.key()));
+                }
                 System.out.println();
             }
 

--- a/src/main/java/io/telicent/jira/sync/cli/commands/issues/ComputeCrossLinks.java
+++ b/src/main/java/io/telicent/jira/sync/cli/commands/issues/ComputeCrossLinks.java
@@ -1,4 +1,4 @@
-package io.telicent.jira.sync.cli.commands;
+package io.telicent.jira.sync.cli.commands.issues;
 
 import com.atlassian.jira.issue.link.RemoteIssueLink;
 import com.atlassian.jira.rest.client.api.RestClientException;
@@ -8,6 +8,7 @@ import com.atlassian.jira.rest.client.api.domain.SearchResult;
 import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Command;
 import io.atlassian.util.concurrent.Promise;
+import io.telicent.jira.sync.cli.commands.JiraProjectSyncCommand;
 import io.telicent.jira.sync.cli.options.CrossLinkOptions;
 import io.telicent.jira.sync.client.AsynchronousRemoteLinksClient;
 import io.telicent.jira.sync.client.EnhancedJiraRestClient;
@@ -18,7 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.io.IOException;
 
 @Command(name = "cross-links", description = "Command that calculates the cross-links between GitHub and JIRA")
-public class ComputeCrossLinks extends JiraSyncCommand {
+public class ComputeCrossLinks extends JiraProjectSyncCommand {
 
     public static final String GITHUB_LINK_ID_PREFIX = "github:";
     @AirlineModule

--- a/src/main/java/io/telicent/jira/sync/cli/commands/issues/ComputeCrossLinks.java
+++ b/src/main/java/io/telicent/jira/sync/cli/commands/issues/ComputeCrossLinks.java
@@ -10,13 +10,19 @@ import com.github.rvesse.airline.annotations.Command;
 import io.atlassian.util.concurrent.Promise;
 import io.telicent.jira.sync.cli.commands.JiraProjectSyncCommand;
 import io.telicent.jira.sync.cli.options.CrossLinkOptions;
+import io.telicent.jira.sync.client.AsynchronousIssueCommentsClient;
 import io.telicent.jira.sync.client.AsynchronousRemoteLinksClient;
 import io.telicent.jira.sync.client.EnhancedJiraRestClient;
+import io.telicent.jira.sync.client.model.Comment;
+import io.telicent.jira.sync.client.model.CommentProperty;
 import io.telicent.jira.sync.client.model.CrossLinkedProject;
 import io.telicent.jira.sync.client.model.CrossLinks;
+import io.telicent.jira.sync.utils.JiraUtils;
+import org.apache.commons.collections4.IterableUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
+import java.util.Map;
 
 @Command(name = "cross-links", description = "Command that calculates the cross-links between GitHub and JIRA")
 public class ComputeCrossLinks extends JiraProjectSyncCommand {
@@ -49,6 +55,7 @@ public class ComputeCrossLinks extends JiraProjectSyncCommand {
                 SearchResult searchResults = searchPromise.claim();
 
                 AsynchronousRemoteLinksClient remoteLinksClient = jiraRestClient.getRemoteLinksClient();
+                AsynchronousIssueCommentsClient commentsClient = jiraRestClient.getCommentsClient();
                 for (Issue issue : searchResults.getIssues()) {
                     Promise<Iterable<RemoteIssueLink>> remoteLinksPromise =
                             remoteLinksClient.getRemoteLinks(issue.getKey());
@@ -62,6 +69,23 @@ public class ComputeCrossLinks extends JiraProjectSyncCommand {
                         }
                     }
                     jiraToGitHub.getLastSyncedIds().put(this.jiraOptions.getProjectKey(), issue.getKey());
+
+                    Promise<Iterable<Comment>> commentsPromise = commentsClient.getComments(issue.getKey());
+                    Iterable<Comment> comments = commentsPromise.claim();
+                    Promise<Iterable<Comment>> commentsByIdPromise = commentsClient.getCommentsByIds(
+                            IterableUtils.toList(comments).stream().map(c -> c.getId().toString()).toList());
+                    comments = commentsByIdPromise.claim();
+                    for (Comment comment : comments) {
+                        CommentProperty jiraSyncProperty = comment.getProperty(JiraUtils.COMMENT_PROPERTY_KEY);
+                        if (jiraSyncProperty != null) {
+                            String gitHubCommentId = ((Map<String, String>) jiraSyncProperty.value()).get(
+                                    JiraUtils.GITHUB_COMMENT_ID_PROPERTY);
+                            String jiraCommentId = JiraUtils.getJiraCommentId(issue.getKey(), comment);
+                            jiraToGitHub.setLinks(jiraCommentId, gitHubCommentId);
+                            githubToJira.setLinks(gitHubCommentId, jiraCommentId);
+                            System.out.println("Discovered cross link " + jiraCommentId + " -> " + gitHubCommentId);
+                        }
+                    }
 
                     processed++;
                 }

--- a/src/main/java/io/telicent/jira/sync/cli/commands/issues/Fields.java
+++ b/src/main/java/io/telicent/jira/sync/cli/commands/issues/Fields.java
@@ -1,0 +1,51 @@
+package io.telicent.jira.sync.cli.commands.issues;
+
+import com.atlassian.jira.rest.client.api.JiraRestClient;
+import com.atlassian.jira.rest.client.api.RestClientException;
+import com.atlassian.jira.rest.client.api.domain.Field;
+import com.atlassian.jira.rest.client.api.domain.FieldType;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import io.atlassian.util.concurrent.Promise;
+import io.telicent.jira.sync.cli.commands.JiraSyncCommand;
+
+import java.io.IOException;
+
+@Command(name = "jira-fields", description = "Finds the available JIRA Fields")
+public class Fields extends JiraSyncCommand {
+
+    @Option(name = "--ignore-jira-builtins", description = "When set ignores JIRA built-in fields causing only custom fields to be listed")
+    private boolean ignoreJiraBuiltIns = false;
+
+    @Override
+    public int run() {
+        System.out.println("Retrieving JIRA Fields...");
+        System.out.println();
+
+        try (JiraRestClient jira = this.jiraOptions.connect()) {
+            Promise<Iterable<Field>> promise = jira.getMetadataClient().getFields();
+            Iterable<Field> fields = promise.claim();
+            int fieldsFound = 0;
+            for (Field field : fields) {
+                if (this.ignoreJiraBuiltIns && field.getFieldType() == FieldType.JIRA) {
+                    continue;
+                }
+                fieldsFound++;
+                System.out.println("Field ID: " + field.getId());
+                System.out.println("Name: " + field.getName());
+                System.out.println("Type: " + field.getFieldType());
+                System.out.println();
+            }
+            if (fieldsFound == 0) {
+                System.out.println("No Fields Found!");
+            }
+
+            return 0;
+        } catch (RestClientException e) {
+            this.reportJiraRestError(e);
+            return 1;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/cli/commands/issues/GitHubToJira.java
+++ b/src/main/java/io/telicent/jira/sync/cli/commands/issues/GitHubToJira.java
@@ -1,4 +1,4 @@
-package io.telicent.jira.sync.cli.commands;
+package io.telicent.jira.sync.cli.commands.issues;
 
 import com.atlassian.adf.jackson2.AdfJackson2;
 import com.atlassian.adf.markdown.MarkdownParser;
@@ -17,21 +17,26 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
-import com.github.rvesse.airline.annotations.restrictions.RequireOnlyOne;
 import com.github.rvesse.airline.annotations.restrictions.Required;
 import io.atlassian.util.concurrent.Promise;
+import io.telicent.jira.sync.cli.commands.JiraGitHubSyncCommand;
 import io.telicent.jira.sync.cli.options.CrossLinkOptions;
 import io.telicent.jira.sync.cli.options.JiraIssueTypeMappingOptions;
+import io.telicent.jira.sync.client.AsynchronousIssueCommentsClient;
 import io.telicent.jira.sync.client.AsynchronousRemoteLinksClient;
 import io.telicent.jira.sync.client.EnhancedJiraRestClient;
-import io.telicent.jira.sync.client.model.BasicRemoteLink;
-import io.telicent.jira.sync.client.model.CrossLinks;
-import io.telicent.jira.sync.client.model.RemoteLinkInput;
+import io.telicent.jira.sync.client.model.*;
 import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.github.*;
+import org.kohsuke.github.GHFileNotFoundException;
+import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHIssueComment;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
 
-import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 @Command(name = "to-jira", description = "Command for synchronising GitHub Issues to JIRA")
@@ -53,7 +58,10 @@ public class GitHubToJira extends JiraGitHubSyncCommand {
     @AirlineModule
     private CrossLinkOptions crossLinkOptions = new CrossLinkOptions();
 
-    @Option(name = "--skip-existing", description = "When specified skips sync'ing issues that have already been sync'd to JIRA, this means any changes on the GitHub issue are not reflected in the JIRA but reduces the number of spurious JIRA updates")
+    @Option(name = "--include-comments", description = "When specified also sync's any GitHub issue comments across into JIRA issue comments.")
+    private boolean includeComments = false;
+
+    @Option(name = "--skip-existing", description = "When specified skips sync'ing issues that have already been sync'd to JIRA, this means any changes on the GitHub issue are not reflected in the JIRA but reduces the number of spurious JIRA updates.")
     private boolean skipExisting = false;
 
     @Option(name = "--dry-run", description = "When specified print what would happen without actually performing the actions i.e. preview what the results of running the command would be")
@@ -115,6 +123,9 @@ public class GitHubToJira extends JiraGitHubSyncCommand {
         if (StringUtils.isNotBlank(jiraKey) && this.skipExisting) {
             System.out.println(
                     "Skipping Issue #" + issue.getNumber() + " which syncs to existing JIRA Issue " + jiraKey + " as --skip-existing was set");
+
+            // Might be new comments even if the issue itself has been sync'd across
+            this.syncIssueComments(crossLinks, jiraRestClient, issue, jiraKey);
             return;
         }
 
@@ -122,15 +133,14 @@ public class GitHubToJira extends JiraGitHubSyncCommand {
         IssueRestClient issues = jiraRestClient.getIssueClient();
         long jiraIssueType = this.jiraIssueTypeMappingOptions.getJiraIssueType(issue);
         System.out.println("GitHub issue " + gitHubIssueId + " will be synced as JIRA Issue Type " + jiraIssueType);
-        IssueInput input =
-                new IssueInputBuilder().setIssueTypeId(jiraIssueType)
-                                       .setProjectKey(this.jiraOptions.getProjectKey())
-                                       .setFieldInput(new FieldInput(IssueFieldId.DESCRIPTION_FIELD,
-                                                                     translateMarkdownToAdf(issue)))
-                                       .setSummary(issue.getTitle())
-                                       // TODO Copy assignee where relevant
-                                       // TODO Figure out if/how to copy labels across
-                                       .build();
+        IssueInput input = new IssueInputBuilder().setIssueTypeId(jiraIssueType)
+                                                  .setProjectKey(this.jiraOptions.getProjectKey())
+                                                  .setFieldInput(new FieldInput(IssueFieldId.DESCRIPTION_FIELD,
+                                                                                translateMarkdownToAdf(issue)))
+                                                  .setSummary(issue.getTitle())
+                                                  // TODO Copy assignee where relevant
+                                                  // TODO Figure out if/how to copy labels across
+                                                  .build();
 
         if (StringUtils.isNotBlank(jiraKey)) {
             System.out.println("GitHub Issue " + gitHubIssueId + " syncs to existing JIRA Issue " + jiraKey);
@@ -149,16 +159,13 @@ public class GitHubToJira extends JiraGitHubSyncCommand {
                 System.out.println("Created new JIRA Issue " + created.getKey());
 
                 // Update the cross-links with the new links
-                // NB - We don't update the last sync'd ID as ComputeCrossLinks does because there might be issue creation
-                //      happening on the JIRA side which we haven't sync'd the other way yet
-                crossLinks.getGitHubToJira().setLinks(gitHubIssueId, created.getKey());
-                crossLinks.getJiraToGitHub().setLinks(created.getKey(), gitHubIssueId);
-                this.crossLinkOptions.saveCrossLinks();
+                updateCrossLinks(crossLinks, gitHubIssueId, created.getKey());
 
                 // Need the JIRA Key later for creating the remote link from JIRA back to the original GitHub Issue
                 jiraKey = created.getKey();
             } else {
                 System.out.println("[DRY RUN] Would have created a new JIRA Issue");
+                jiraKey = this.jiraOptions.getProjectKey() + "-?";
             }
 
             // TODO If there's a JIRA Key mentioned in the issue automatically add issue links?
@@ -175,23 +182,75 @@ public class GitHubToJira extends JiraGitHubSyncCommand {
             Promise<BasicRemoteLink> createdLinkPromise =
                     remoteLinksClient.createOrUpdateRemoteLink(jiraKey, remoteLink);
             BasicRemoteLink createdLink = createdLinkPromise.claim();
-            System.out.println(
-                    "Associated GitHub Issue with JIRA Issue via Remote Link ID " + createdLink.getId());
+            System.out.println("Associated GitHub Issue with JIRA Issue via Remote Link ID " + createdLink.getId());
         } else {
             System.out.println("[DRY RUN] Would have created/updated a Remote Link from JIRA to the GitHub Issue");
         }
 
         // TODO If the GH Issue is closed apply a suitable transition to the JIRA Issue if it isn't also closed?
 
-        // TODO Sync Issue Comments if desired?
+        // Sync Issue Comments if enabled
+        this.syncIssueComments(crossLinks, jiraRestClient, issue, jiraKey);
+    }
+
+    private void updateCrossLinks(CrossLinks crossLinks, String gitHubId, String jiraId) throws IOException {
+        // NB - We don't update the last sync'd ID as ComputeCrossLinks does because there might be issue creation
+        //      happening on the JIRA side which we haven't sync'd the other way yet
+        crossLinks.getGitHubToJira().setLinks(gitHubId, jiraId);
+        crossLinks.getJiraToGitHub().setLinks(jiraId, gitHubId);
+        this.crossLinkOptions.saveCrossLinks();
+    }
+
+    private void syncIssueComments(CrossLinks crossLinks, EnhancedJiraRestClient jira, GHIssue issue,
+                                   String jiraIssueKey) throws
+            IOException {
+        if (!this.includeComments) {
+            return;
+        }
+
+        AsynchronousIssueCommentsClient commentsClient = jira.getCommentsClient();
+
+        System.out.println(
+                "Syncing comments for GitHub Issue " + issue.getNumber() + " to JIRA Issue " + jiraIssueKey + "...");
+        for (GHIssueComment ghComment : issue.listComments()) {
+            String gitHubCommentId = this.ghRepo + "/" + issue.getNumber() + "/comments/" + ghComment.getId();
+            String jiraCommentId = crossLinks.getGitHubToJira().getLinks().get(gitHubCommentId);
+            if (StringUtils.isNotBlank(jiraCommentId) && this.skipExisting) {
+                System.out.println(
+                        "Skipping Issue #" + issue.getNumber() + " Comment " + ghComment.getId() + " which syncs to existing JIRA Comment " + jiraCommentId + " as --skip-existing was set");
+                continue;
+            }
+
+            CommentInput commentInput = new CommentInput(translateMarkdownToAdfDocument(ghComment.getBody()),
+                                                         List.of(new CommentProperty("io.telicent.jira-sync",
+                                                                                     gitHubCommentId)), null);
+            if (!this.dryRun) {
+                Promise<Comment> commentCreation = StringUtils.isNotBlank(jiraCommentId) ?
+                                                   commentsClient.updateComment(jiraIssueKey, jiraCommentId,
+                                                                                commentInput) :
+                                                   commentsClient.addComment(jiraIssueKey, commentInput);
+                Comment created = commentCreation.claim();
+                updateCrossLinks(crossLinks, gitHubCommentId, created.getId().toString());
+                System.out.println((StringUtils.isNotBlank(jiraCommentId) ? "Updated" :
+                                    "Created") + " a JIRA Comment on JIRA " + jiraIssueKey + " for GitHub Comment " + ghComment.getId());
+            } else {
+                System.out.println(
+                        "[DRY RUN] Would have created/updated an Issue Comment on JIRA Issue " + jiraIssueKey + " for GitHub Comment " + ghComment.getId());
+            }
+        }
+        System.out.println("All comments for GitHub Issue " + issue.getNumber() + " synced to JIRA Issue " + jiraIssueKey);
     }
 
     private static Object translateMarkdownToAdf(GHIssue issue) throws JsonProcessingException {
-        MarkdownParser parser = new MarkdownParser();
-        Doc doc = parser.unmarshall(issue.getBody());
+        Doc doc = translateMarkdownToAdfDocument(issue.getBody());
         AdfJackson2 jackson = new AdfJackson2();
         String json = jackson.marshall(doc);
         Map<String, Object> map = new ObjectMapper().readValue(json, GENERIC_MAP_TYPE);
         return new ComplexIssueInputFieldValue(map);
+    }
+
+    private static Doc translateMarkdownToAdfDocument(String markdown) {
+        MarkdownParser parser = new MarkdownParser();
+        return parser.unmarshall(markdown);
     }
 }

--- a/src/main/java/io/telicent/jira/sync/cli/commands/issues/IssueTypes.java
+++ b/src/main/java/io/telicent/jira/sync/cli/commands/issues/IssueTypes.java
@@ -1,4 +1,4 @@
-package io.telicent.jira.sync.cli.commands;
+package io.telicent.jira.sync.cli.commands.issues;
 
 import com.atlassian.jira.rest.client.api.GetCreateIssueMetadataOptionsBuilder;
 import com.atlassian.jira.rest.client.api.IssueRestClient;
@@ -8,11 +8,12 @@ import com.atlassian.jira.rest.client.api.domain.CimIssueType;
 import com.atlassian.jira.rest.client.api.domain.CimProject;
 import com.github.rvesse.airline.annotations.Command;
 import io.atlassian.util.concurrent.Promise;
+import io.telicent.jira.sync.cli.commands.JiraProjectSyncCommand;
 
 import java.io.IOException;
 
 @Command(name = "jira-types", description = "Finds the available JIRA Issue Types for the specified JIRA Project")
-public class IssueTypes extends JiraSyncCommand {
+public class IssueTypes extends JiraProjectSyncCommand {
     @Override
     public int run() {
         try (JiraRestClient jira = this.jiraOptions.connect()) {

--- a/src/main/java/io/telicent/jira/sync/cli/commands/issues/RemoteLinks.java
+++ b/src/main/java/io/telicent/jira/sync/cli/commands/issues/RemoteLinks.java
@@ -1,4 +1,4 @@
-package io.telicent.jira.sync.cli.commands;
+package io.telicent.jira.sync.cli.commands.issues;
 
 import com.atlassian.jira.issue.link.RemoteIssueLink;
 import com.atlassian.jira.rest.client.api.RestClientException;
@@ -6,13 +6,14 @@ import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.restrictions.Required;
 import io.atlassian.util.concurrent.Promise;
+import io.telicent.jira.sync.cli.commands.JiraProjectSyncCommand;
 import io.telicent.jira.sync.client.AsynchronousRemoteLinksClient;
 import io.telicent.jira.sync.client.EnhancedJiraRestClient;
 
 import java.io.IOException;
 
 @Command(name = "remote-links", description = "Retrieves the remote links associated with a JIRA Issue")
-public class RemoteLinks extends JiraSyncCommand{
+public class RemoteLinks extends JiraProjectSyncCommand {
 
     @Option(name = "--jira-issue", title = "JiraIssue", description = "Specifies the key of a JIRA Issue")
     @Required

--- a/src/main/java/io/telicent/jira/sync/cli/options/JiraOptions.java
+++ b/src/main/java/io/telicent/jira/sync/cli/options/JiraOptions.java
@@ -38,11 +38,6 @@ public class JiraOptions {
     @NotBlank
     private String jiraTokenEnv;
 
-    @Option(name = "--jira-project-key", title = "JiraProjectKey", description = "Specifies the name of the JIRA Project Key for the JIRA project you want to sync against")
-    @Required
-    @NotBlank
-    private String jiraProjectKey;
-
     private EnhancedJiraRestClient instance = null;
 
     public EnhancedJiraRestClient connect() {
@@ -81,12 +76,4 @@ public class JiraOptions {
         }
     }
 
-    /**
-     * Gets the JIRA Project Key for the project the user wants to sync against
-     *
-     * @return JIRA Project Key
-     */
-    public String getProjectKey() {
-        return this.jiraProjectKey;
-    }
 }

--- a/src/main/java/io/telicent/jira/sync/cli/options/JiraProjectOptions.java
+++ b/src/main/java/io/telicent/jira/sync/cli/options/JiraProjectOptions.java
@@ -1,0 +1,21 @@
+package io.telicent.jira.sync.cli.options;
+
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.NotBlank;
+import com.github.rvesse.airline.annotations.restrictions.Required;
+
+public class JiraProjectOptions extends JiraOptions{
+    @Option(name = "--jira-project-key", title = "JiraProjectKey", description = "Specifies the name of the JIRA Project Key for the JIRA project you want to sync against")
+    @Required
+    @NotBlank
+    private String jiraProjectKey;
+
+    /**
+     * Gets the JIRA Project Key for the project the user wants to sync against
+     *
+     * @return JIRA Project Key
+     */
+    public String getProjectKey() {
+        return this.jiraProjectKey;
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/AsynchronousIssueCommentsClient.java
+++ b/src/main/java/io/telicent/jira/sync/client/AsynchronousIssueCommentsClient.java
@@ -1,0 +1,66 @@
+package io.telicent.jira.sync.client;
+
+import com.atlassian.httpclient.api.HttpClient;
+import com.atlassian.jira.rest.client.internal.async.AbstractAsynchronousRestClient;
+import io.atlassian.util.concurrent.Promise;
+import io.telicent.jira.sync.client.generator.CommentGenerator;
+import io.telicent.jira.sync.client.model.Comment;
+import io.telicent.jira.sync.client.model.CommentInput;
+import io.telicent.jira.sync.client.parser.CommentParser;
+import io.telicent.jira.sync.client.parser.PagedCommentsParser;
+import org.jetbrains.annotations.NotNull;
+
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+
+public class AsynchronousIssueCommentsClient extends AbstractAsynchronousRestClient {
+
+    private final PagedCommentsParser commentsParser = new PagedCommentsParser();
+    private final CommentParser commentParser = new CommentParser();
+    private final CommentGenerator commentGenerator = new CommentGenerator();
+    private final URI baseUri;
+
+    public AsynchronousIssueCommentsClient(URI baseUri, HttpClient client) {
+        super(client);
+        this.baseUri = baseUri;
+    }
+
+    private @NotNull UriBuilder buildCommentApiUri(String issueKey) {
+        //@formatter:off
+        return UriBuilder.fromUri(this.baseUri)
+                         .path("issue")
+                         .path(issueKey)
+                         .path("comment");
+        //@formatter:on
+    }
+
+    private @NotNull UriBuilder buildUriForComment(String issueKey, String commentId) {
+        return buildCommentApiUri(issueKey).path(commentId);
+    }
+
+    public Promise<Iterable<Comment>> getComments(String issueKey) {
+        UriBuilder uriBuilder = buildCommentApiUri(issueKey);
+        return this.getAndParse(uriBuilder.build(), this.commentsParser);
+    }
+
+    public Promise<Comment> getComment(String issueKey, String commentId) {
+        UriBuilder uriBuilder = buildUriForComment(issueKey, commentId);
+        return this.getAndParse(uriBuilder.build(), this.commentParser);
+    }
+
+
+    public Promise<Comment> addComment(String issueKey, CommentInput commentInput) {
+        UriBuilder uriBuilder = buildCommentApiUri(issueKey);
+        return this.postAndParse(uriBuilder.build(), commentInput, this.commentGenerator, this.commentParser);
+    }
+
+    public Promise<Comment> updateComment(String issueKey, String commentId, CommentInput commentInput) {
+        UriBuilder uriBuilder = buildUriForComment(issueKey, commentId);
+        return this.putAndParse(uriBuilder.build(), commentInput, this.commentGenerator, this.commentParser);
+    }
+
+    public Promise<Void> deleteComment(String issueKey, String commentId) {
+        UriBuilder uriBuilder = buildUriForComment(issueKey, commentId);
+        return this.delete(uriBuilder.build());
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/EnhancedJiraRestClient.java
+++ b/src/main/java/io/telicent/jira/sync/client/EnhancedJiraRestClient.java
@@ -11,6 +11,7 @@ public class EnhancedJiraRestClient extends AsynchronousJiraRestClient {
 
     private final AsynchronousRemoteLinksClient remoteLinksClient;
     private final EnhancedIssuesRestClient enhancedIssuesClient;
+    private final AsynchronousIssueCommentsClient commentsClient;
 
     public EnhancedJiraRestClient(URI serverUri,
                                   DisposableHttpClient httpClient) {
@@ -19,12 +20,29 @@ public class EnhancedJiraRestClient extends AsynchronousJiraRestClient {
         URI baseUri = UriBuilder.fromUri(serverUri).path("/rest/api/latest").build();
         this.remoteLinksClient = new AsynchronousRemoteLinksClient(baseUri, httpClient);
 
+        // For these API Clients want to explicitly use the v3 API
         URI v3Uri = UriBuilder.fromUri(serverUri).path("/rest/api/3").build();
-        this.enhancedIssuesClient = new EnhancedIssuesRestClient(v3Uri, httpClient, this.getSessionClient(), this.getMetadataClient());
+        this.enhancedIssuesClient =
+                new EnhancedIssuesRestClient(v3Uri, httpClient, this.getSessionClient(), this.getMetadataClient());
+        this.commentsClient = new AsynchronousIssueCommentsClient(v3Uri, httpClient);
     }
 
+    /**
+     * Gets an API Client for manipulating issue remote links
+     *
+     * @return Issue Remote Links API Client
+     */
     public AsynchronousRemoteLinksClient getRemoteLinksClient() {
         return this.remoteLinksClient;
+    }
+
+    /**
+     * Gets an API Client for manipulating issue comments
+     *
+     * @return Issue Comments API Client
+     */
+    public AsynchronousIssueCommentsClient getCommentsClient() {
+        return this.commentsClient;
     }
 
     @Override

--- a/src/main/java/io/telicent/jira/sync/client/generator/CommentGenerator.java
+++ b/src/main/java/io/telicent/jira/sync/client/generator/CommentGenerator.java
@@ -29,6 +29,7 @@ public class CommentGenerator implements JsonGenerator<Comment> {
             for (CommentProperty p : comment.getProperties()) {
                 properties.put(this.commentPropertyGenerator.generate(p));
             }
+            json.put("properties", properties);
         }
 
         return json;

--- a/src/main/java/io/telicent/jira/sync/client/generator/CommentGenerator.java
+++ b/src/main/java/io/telicent/jira/sync/client/generator/CommentGenerator.java
@@ -1,0 +1,36 @@
+package io.telicent.jira.sync.client.generator;
+
+import com.atlassian.jira.entity.property.EntityProperty;
+import com.atlassian.jira.rest.client.internal.json.gen.JsonGenerator;
+import com.atlassian.jira.rest.client.internal.json.gen.VisibilityJsonGenerator;
+import io.telicent.jira.sync.client.model.Comment;
+import io.telicent.jira.sync.client.model.CommentProperty;
+import org.apache.commons.collections4.CollectionUtils;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+
+public class CommentGenerator implements JsonGenerator<Comment> {
+
+    private final DocGenerator docGenerator = new DocGenerator();
+    private final VisibilityJsonGenerator visGenerator = new VisibilityJsonGenerator();
+    private final CommentPropertyGenerator commentPropertyGenerator = new CommentPropertyGenerator();
+
+    @Override
+    public JSONObject generate(Comment comment) throws JSONException {
+        JSONObject json = new JSONObject();
+
+        json.put("body", docGenerator.generate(comment.getBodyDocument()));
+        if (comment.getVisibility() != null) {
+            json.put("visibility", visGenerator.generate(comment.getVisibility()));
+        }
+        if (CollectionUtils.isNotEmpty(comment.getProperties())) {
+            JSONArray properties = new JSONArray();
+            for (CommentProperty p : comment.getProperties()) {
+                properties.put(this.commentPropertyGenerator.generate(p));
+            }
+        }
+
+        return json;
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/generator/CommentPropertyGenerator.java
+++ b/src/main/java/io/telicent/jira/sync/client/generator/CommentPropertyGenerator.java
@@ -1,0 +1,29 @@
+package io.telicent.jira.sync.client.generator;
+
+import com.atlassian.jira.rest.client.internal.json.gen.JsonGenerator;
+import io.telicent.jira.sync.client.model.CommentProperty;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+
+import java.util.List;
+import java.util.Map;
+
+public class CommentPropertyGenerator implements JsonGenerator<CommentProperty> {
+    private final MapGenerator mapGenerator = new MapGenerator();
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public JSONObject generate(CommentProperty property) throws JSONException {
+        JSONObject json = new JSONObject();
+        json.put("key", property.key());
+        if (property.value() instanceof Map<?, ?> map) {
+            json.put("value", this.mapGenerator.generate((Map<String, ?>) map));
+        } else if (property.value() instanceof List<?> list) {
+            json.put("value", this.mapGenerator.generateList((List<Object>) list));
+        } else {
+            json.put("value", property.value());
+        }
+
+        return json;
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/generator/DocGenerator.java
+++ b/src/main/java/io/telicent/jira/sync/client/generator/DocGenerator.java
@@ -1,0 +1,16 @@
+package io.telicent.jira.sync.client.generator;
+
+import com.atlassian.adf.model.node.Doc;
+import com.atlassian.jira.rest.client.internal.json.gen.JsonGenerator;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+
+public class DocGenerator implements JsonGenerator<Doc> {
+
+    private final MapGenerator mapGenerator = new MapGenerator();
+
+    @Override
+    public JSONObject generate(Doc doc) throws JSONException {
+        return this.mapGenerator.generate(doc.toMap());
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/generator/EnhancedComplexIssueInputFieldValueJsonGenerator.java
+++ b/src/main/java/io/telicent/jira/sync/client/generator/EnhancedComplexIssueInputFieldValueJsonGenerator.java
@@ -1,5 +1,6 @@
 package io.telicent.jira.sync.client.generator;
 
+import com.atlassian.adf.model.node.Doc;
 import com.atlassian.jira.rest.client.api.domain.input.ComplexIssueInputFieldValue;
 import com.atlassian.jira.rest.client.internal.json.gen.ComplexIssueInputFieldValueJsonGenerator;
 import org.codehaus.jettison.json.JSONException;
@@ -7,12 +8,16 @@ import org.codehaus.jettison.json.JSONException;
 import java.util.Map;
 
 public class EnhancedComplexIssueInputFieldValueJsonGenerator extends ComplexIssueInputFieldValueJsonGenerator {
+    private DocGenerator docGenerator = new DocGenerator();
+
     @Override
     public Object generateFieldValueForJson(Object rawValue) throws JSONException {
         if (rawValue instanceof Map<?, ?>) {
             // HACK: JIRA's code doesn't handle raw Map, unless we wrap in a ComplexIssueInputFieldValue, so we just
             //       do that as a workaround
             return super.generateFieldValueForJson(new ComplexIssueInputFieldValue((Map<String, Object>) rawValue));
+        } else if (rawValue instanceof Doc doc) {
+            return docGenerator.generate(doc);
         }
         return super.generateFieldValueForJson(rawValue);
     }

--- a/src/main/java/io/telicent/jira/sync/client/generator/MapGenerator.java
+++ b/src/main/java/io/telicent/jira/sync/client/generator/MapGenerator.java
@@ -1,0 +1,48 @@
+package io.telicent.jira.sync.client.generator;
+
+import com.atlassian.jira.rest.client.internal.json.gen.JsonGenerator;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A JSON Generator that deals with complex maps
+ */
+public class MapGenerator implements JsonGenerator<Map<String, ?>> {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public JSONObject generate(Map<String, ?> map) throws JSONException {
+        JSONObject json = new JSONObject();
+        for (Map.Entry<String, ?> entry : map.entrySet()) {
+            if (entry.getValue() instanceof Map<?, ?> childMap) {
+                json.put(entry.getKey(), generate((Map<String, ?>) childMap));
+            } else if (entry.getValue() instanceof List<?> list) {
+                json.put(entry.getKey(), generateList((List<Object>) list));
+            } else {
+                json.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return json;
+    }
+
+    @SuppressWarnings("unchecked")
+    public JSONArray generateList(List<Object> list) throws JSONException {
+        JSONArray json = new JSONArray();
+        for (Object obj : list) {
+            if (obj instanceof Map<?, ?> childMap) {
+                json.put(generate((Map<String, ?>) childMap));
+            } else if (obj instanceof List<?>) {
+                json.put(generateList(list));
+            } else {
+                json.put(obj);
+            }
+        }
+
+        return json;
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/model/Comment.java
+++ b/src/main/java/io/telicent/jira/sync/client/model/Comment.java
@@ -1,0 +1,44 @@
+package io.telicent.jira.sync.client.model;
+
+import com.atlassian.adf.model.node.Doc;
+import com.atlassian.jira.entity.property.EntityProperty;
+import com.atlassian.jira.rest.client.api.domain.BasicUser;
+import com.atlassian.jira.rest.client.api.domain.Visibility;
+import org.jetbrains.annotations.Nullable;
+import org.joda.time.DateTime;
+
+import java.net.URI;
+import java.util.List;
+
+public class Comment extends com.atlassian.jira.rest.client.api.domain.Comment {
+    private final Doc body;
+    private final List<CommentProperty> properties;
+
+    public Comment(@Nullable URI self, @Nullable Doc body, @Nullable List<CommentProperty> properties,
+                   @Nullable BasicUser author, @Nullable BasicUser updateAuthor, @Nullable DateTime creationDate,
+                   @Nullable DateTime updateDate, @Nullable Visibility visibility, @Nullable Long id) {
+        super(self, null, author, updateAuthor, creationDate, updateDate, visibility, id);
+
+        this.body = body;
+        this.properties = properties;
+    }
+
+
+    /**
+     * Gets the comment body as an Atlassian Document
+     *
+     * @return Body document
+     */
+    public Doc getBodyDocument() {
+        return this.body;
+    }
+
+    /**
+     * Gets the comment properties (if any)
+     *
+     * @return Properties
+     */
+    public List<CommentProperty> getProperties() {
+        return this.properties;
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/model/Comment.java
+++ b/src/main/java/io/telicent/jira/sync/client/model/Comment.java
@@ -9,6 +9,7 @@ import org.joda.time.DateTime;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Objects;
 
 public class Comment extends com.atlassian.jira.rest.client.api.domain.Comment {
     private final Doc body;
@@ -40,5 +41,17 @@ public class Comment extends com.atlassian.jira.rest.client.api.domain.Comment {
      */
     public List<CommentProperty> getProperties() {
         return this.properties;
+    }
+
+    /**
+     * Gets the comment property with the specific key (if present)
+     * @param key Key
+     * @return Comment Property, or {@code null} if no such property
+     */
+    public CommentProperty getProperty(String key) {
+        if (this.properties == null) {
+            return null;
+        }
+        return this.properties.stream().filter(p -> Objects.equals(p.key(), key)).findFirst().orElse(null);
     }
 }

--- a/src/main/java/io/telicent/jira/sync/client/model/CommentInput.java
+++ b/src/main/java/io/telicent/jira/sync/client/model/CommentInput.java
@@ -1,0 +1,19 @@
+package io.telicent.jira.sync.client.model;
+
+import com.atlassian.adf.model.node.Doc;
+import com.atlassian.jira.rest.client.api.domain.Visibility;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class CommentInput extends Comment {
+    /**
+     * Creates a new comment input
+     *
+     * @param body       Comment body
+     * @param visibility Comment visibility
+     */
+    public CommentInput(Doc body, List<CommentProperty> properties, @Nullable Visibility visibility) {
+        super(null, body, properties, null, null, null, null, visibility, null);
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/model/CommentProperty.java
+++ b/src/main/java/io/telicent/jira/sync/client/model/CommentProperty.java
@@ -1,0 +1,4 @@
+package io.telicent.jira.sync.client.model;
+
+public record CommentProperty(String key, Object value) {
+}

--- a/src/main/java/io/telicent/jira/sync/client/parser/AbstractArrayParser.java
+++ b/src/main/java/io/telicent/jira/sync/client/parser/AbstractArrayParser.java
@@ -1,0 +1,20 @@
+package io.telicent.jira.sync.client.parser;
+
+import com.atlassian.jira.rest.client.internal.json.GenericJsonArrayParser;
+import com.atlassian.jira.rest.client.internal.json.JsonArrayParser;
+import com.atlassian.jira.rest.client.internal.json.JsonObjectParser;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+
+public class AbstractArrayParser<T> implements JsonArrayParser<Iterable<T>> {
+    private final GenericJsonArrayParser<T> itemParser;
+
+    public AbstractArrayParser(JsonObjectParser<T> parser) {
+        this.itemParser = new GenericJsonArrayParser<>(parser);
+    }
+
+    @Override
+    public Iterable<T> parse(JSONArray jsonArray) throws JSONException {
+        return this.itemParser.parse(jsonArray);
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/parser/AbstractWrappedArrayParser.java
+++ b/src/main/java/io/telicent/jira/sync/client/parser/AbstractWrappedArrayParser.java
@@ -1,0 +1,21 @@
+package io.telicent.jira.sync.client.parser;
+
+import com.atlassian.jira.rest.client.internal.json.JsonArrayParser;
+import com.atlassian.jira.rest.client.internal.json.JsonObjectParser;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+
+public class AbstractWrappedArrayParser<T> implements JsonObjectParser<Iterable<T>> {
+    private final JsonArrayParser<Iterable<T>> arrayParser;
+    private final String fieldToUnwrap;
+
+    public AbstractWrappedArrayParser(JsonArrayParser<Iterable<T>> arrayParser, String fieldToUnwrap) {
+        this.arrayParser = arrayParser;
+        this.fieldToUnwrap = fieldToUnwrap;
+    }
+
+    @Override
+    public Iterable<T> parse(JSONObject json) throws JSONException {
+        return this.arrayParser.parse(json.getJSONArray(this.fieldToUnwrap));
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/parser/CommentParser.java
+++ b/src/main/java/io/telicent/jira/sync/client/parser/CommentParser.java
@@ -1,0 +1,42 @@
+package io.telicent.jira.sync.client.parser;
+
+import com.atlassian.adf.model.node.Doc;
+import com.atlassian.jira.rest.client.api.domain.BasicUser;
+import com.atlassian.jira.rest.client.api.domain.Visibility;
+import com.atlassian.jira.rest.client.internal.json.JsonObjectParser;
+import com.atlassian.jira.rest.client.internal.json.JsonParseUtil;
+import com.atlassian.jira.rest.client.internal.json.VisibilityJsonParser;
+import com.google.common.base.Optional;
+import io.telicent.jira.sync.client.model.Comment;
+import io.telicent.jira.sync.client.model.CommentProperty;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+
+import java.net.URI;
+import java.util.List;
+
+public class CommentParser implements JsonObjectParser<Comment> {
+    private final VisibilityJsonParser visParser = new VisibilityJsonParser();
+    private final DocParser docParser = new DocParser();
+    private final CommentPropertyParser commentPropertyParser = new CommentPropertyParser();
+
+    @Override
+    public Comment parse(JSONObject json) throws JSONException {
+        final URI selfUri = JsonParseUtil.getSelfUri(json);
+        final Long id = JsonParseUtil.getOptionalLong(json, "id");
+        final Doc body = this.docParser.parse(json.getJSONObject("body"));
+        final BasicUser author = JsonParseUtil.parseBasicUser(json.optJSONObject("author"));
+        final BasicUser updateAuthor = JsonParseUtil.parseBasicUser(json.optJSONObject("updateAuthor"));
+        final Visibility visibility = visParser.parseVisibility(json);
+        List<CommentProperty> properties = null;
+        Optional<JSONArray> propArray = JsonParseUtil.getOptionalArray(json, "properties");
+        if (propArray.isPresent()) {
+            properties = this.commentPropertyParser.parseList(propArray.get());
+        }
+
+        return new Comment(selfUri, body, properties, author, updateAuthor,
+                           JsonParseUtil.parseDateTime(json.getString("created")),
+                           JsonParseUtil.parseDateTime(json.getString("updated")), visibility, id);
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/parser/CommentPropertyParser.java
+++ b/src/main/java/io/telicent/jira/sync/client/parser/CommentPropertyParser.java
@@ -1,0 +1,28 @@
+package io.telicent.jira.sync.client.parser;
+
+import com.atlassian.jira.rest.client.internal.json.GenericJsonArrayParser;
+import com.atlassian.jira.rest.client.internal.json.JsonObjectParser;
+import io.telicent.jira.sync.client.model.CommentProperty;
+import org.apache.commons.collections4.IterableUtils;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+
+import java.util.List;
+
+public class CommentPropertyParser implements JsonObjectParser<CommentProperty> {
+    private final GenericJsonArrayParser<CommentProperty> listParser = new GenericJsonArrayParser<>(this);
+    private final MapParser mapParser = new MapParser();
+
+    @Override
+    public CommentProperty parse(JSONObject json) throws JSONException {
+        String key = json.getString("key");
+        Object value = this.mapParser.parseValue(json.get("value"));
+        return new CommentProperty(key, value);
+    }
+
+    public List<CommentProperty> parseList(JSONArray json) throws JSONException {
+        Iterable<CommentProperty> iterable = this.listParser.parse(json);
+        return IterableUtils.toList(iterable);
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/parser/CommentsByIdParser.java
+++ b/src/main/java/io/telicent/jira/sync/client/parser/CommentsByIdParser.java
@@ -1,0 +1,10 @@
+package io.telicent.jira.sync.client.parser;
+
+import io.telicent.jira.sync.client.model.Comment;
+
+public class CommentsByIdParser extends AbstractWrappedArrayParser<Comment> {
+
+    public CommentsByIdParser() {
+        super(new CommentsParser(), "values");
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/parser/CommentsParser.java
+++ b/src/main/java/io/telicent/jira/sync/client/parser/CommentsParser.java
@@ -1,0 +1,9 @@
+package io.telicent.jira.sync.client.parser;
+
+import io.telicent.jira.sync.client.model.Comment;
+
+public class CommentsParser extends AbstractArrayParser<Comment> {
+    public CommentsParser() {
+        super(new CommentParser());
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/parser/DocParser.java
+++ b/src/main/java/io/telicent/jira/sync/client/parser/DocParser.java
@@ -1,0 +1,16 @@
+package io.telicent.jira.sync.client.parser;
+
+import com.atlassian.adf.model.node.Doc;
+import com.atlassian.jira.rest.client.internal.json.JsonObjectParser;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+
+public class DocParser implements JsonObjectParser<Doc> {
+
+    private final MapParser mapParser = new MapParser();
+
+    @Override
+    public Doc parse(JSONObject json) throws JSONException {
+        return Doc.parse(this.mapParser.parse(json));
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/parser/MapParser.java
+++ b/src/main/java/io/telicent/jira/sync/client/parser/MapParser.java
@@ -1,0 +1,55 @@
+package io.telicent.jira.sync.client.parser;
+
+import com.atlassian.jira.rest.client.internal.json.JsonObjectParser;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.codehaus.jettison.json.JSONString;
+
+import java.util.*;
+
+public class MapParser implements JsonObjectParser<Map<String, ?>> {
+    @Override
+    public Map<String, ?> parse(JSONObject json) throws JSONException {
+        Map<String, Object> map = new LinkedHashMap<>();
+
+        for (Iterator it = json.keys(); it.hasNext(); ) {
+            String key = (String) it.next();
+            Object value = json.get(key);
+            map.put(key, parseValue(value));
+        }
+
+        return map;
+    }
+
+    public List<Object> parseList(JSONArray json) throws JSONException {
+        List<Object> list = new ArrayList<>();
+        for (int i = 0; i < json.length(); i++) {
+            Object value = json.get(i);
+            list.add(parseValue(value));
+        }
+        return list;
+    }
+
+    public Object parseValue(Object value) throws JSONException {
+        if (value instanceof JSONObject obj) {
+            return parse(obj);
+        } else if (value instanceof JSONArray arr) {
+            return parseList(arr);
+        } else if (value instanceof JSONString str) {
+            return str.toString();
+        } else if (value instanceof String str) {
+            return str;
+        } else if (value instanceof Long l) {
+            return l;
+        } else if (value instanceof Integer i) {
+            return i;
+        } else if (value instanceof Boolean b) {
+            return b;
+        } else if (value instanceof Double d) {
+            return d;
+        } else {
+            throw new JSONException("Unable to convert value of type " + value.getClass());
+        }
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/parser/PagedCommentsParser.java
+++ b/src/main/java/io/telicent/jira/sync/client/parser/PagedCommentsParser.java
@@ -1,0 +1,10 @@
+package io.telicent.jira.sync.client.parser;
+
+import io.telicent.jira.sync.client.model.Comment;
+
+public class PagedCommentsParser extends AbstractWrappedArrayParser<Comment> {
+
+    public PagedCommentsParser() {
+        super(new CommentsParser(), "comments");
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/client/parser/RemoteLinksJsonParser.java
+++ b/src/main/java/io/telicent/jira/sync/client/parser/RemoteLinksJsonParser.java
@@ -3,15 +3,13 @@ package io.telicent.jira.sync.client.parser;
 import com.atlassian.jira.issue.link.RemoteIssueLink;
 import com.atlassian.jira.rest.client.internal.json.GenericJsonArrayParser;
 import com.atlassian.jira.rest.client.internal.json.JsonArrayParser;
+import com.atlassian.jira.rest.client.internal.json.JsonObjectParser;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 
-public class RemoteLinksJsonParser implements JsonArrayParser<Iterable<RemoteIssueLink>> {
-    private final GenericJsonArrayParser<RemoteIssueLink>
-            linksParser = new GenericJsonArrayParser(new RemoteLinkJsonParser());
+public class RemoteLinksJsonParser extends AbstractArrayParser<RemoteIssueLink> {
 
-    @Override
-    public Iterable<RemoteIssueLink> parse(JSONArray jsonArray) throws JSONException {
-        return this.linksParser.parse(jsonArray);
+    public RemoteLinksJsonParser() {
+        super(new RemoteLinkJsonParser());
     }
 }

--- a/src/main/java/io/telicent/jira/sync/utils/GitHubUtils.java
+++ b/src/main/java/io/telicent/jira/sync/utils/GitHubUtils.java
@@ -1,0 +1,61 @@
+package io.telicent.jira.sync.utils;
+
+import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHLabel;
+import org.kohsuke.github.GHUser;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class GitHubUtils {
+    /**
+     * Builds a preamble Markdown text that links back to the original GitHub Issue/Comment
+     *
+     * @param user      User who created the issue/comment
+     * @param createdAt When the issue/comment was created
+     * @param updatedAt When the issue/comment was last updated
+     * @return Preamble
+     * @throws IOException
+     */
+    public static StringBuilder buildPreamble(GHUser user, Date createdAt, Date updatedAt, String action,
+                                              String originalUrl) throws IOException {
+        StringBuilder commentPreamble = new StringBuilder();
+        if (user != null) {
+            commentPreamble.append("GitHub User [")
+                           .append(getUsername(user))
+                           .append("](")
+                           .append(user.getHtmlUrl())
+                           .append(") [")
+                           .append(action)
+                           .append("](")
+                           .append(originalUrl)
+                           .append(") on ")
+                           .append(createdAt.toInstant().toString());
+            if (updatedAt != null && updatedAt.after(createdAt)) {
+                commentPreamble.append(" and was last updated on ").append(updatedAt.toInstant().toString());
+            }
+            commentPreamble.append("\n\n");
+        }
+        return commentPreamble;
+    }
+
+    private static String getUsername(GHUser user) throws IOException {
+        if (user.getName() != null) {
+            return user.getName();
+        } else if (user.getLogin() != null) {
+            return user.getLogin();
+        } else {
+            return Long.toString(user.getId());
+        }
+    }
+
+    public static Object translateLabels(GHIssue issue) {
+        List<String> labels = new ArrayList<>();
+        for (GHLabel label : issue.getLabels()) {
+            labels.add(label.getName());
+        }
+        return labels;
+    }
+}

--- a/src/main/java/io/telicent/jira/sync/utils/JiraUtils.java
+++ b/src/main/java/io/telicent/jira/sync/utils/JiraUtils.java
@@ -1,0 +1,41 @@
+package io.telicent.jira.sync.utils;
+
+import com.atlassian.adf.jackson2.AdfJackson2;
+import com.atlassian.adf.markdown.MarkdownParser;
+import com.atlassian.adf.model.node.Doc;
+import com.atlassian.jira.rest.client.api.domain.input.ComplexIssueInputFieldValue;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.telicent.jira.sync.client.model.Comment;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.kohsuke.github.GHIssue;
+
+import java.util.Map;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class JiraUtils {
+
+    public static final String COMMENT_PROPERTY_KEY = "io.telicent.jira-sync";
+    private static final TypeReference<Map<String, Object>> GENERIC_MAP_TYPE = new TypeReference<>() {
+    };
+    public static final String GITHUB_COMMENT_ID_PROPERTY = "github.comment.id";
+
+    public static String getJiraCommentId(String jiraKey, Comment created) {
+        return String.format("%s/comments/%d", jiraKey, created.getId());
+    }
+
+    public static Object translateMarkdownToAdf(StringBuilder preamble, GHIssue issue) throws JsonProcessingException {
+        Doc doc = translateMarkdownToAdfDocument(preamble + issue.getBody());
+        AdfJackson2 jackson = new AdfJackson2();
+        String json = jackson.marshall(doc);
+        Map<String, Object> map = new ObjectMapper().readValue(json, GENERIC_MAP_TYPE);
+        return new ComplexIssueInputFieldValue(map);
+    }
+
+    public static Doc translateMarkdownToAdfDocument(String markdown) {
+        MarkdownParser parser = new MarkdownParser();
+        return parser.unmarshall(markdown);
+    }
+}

--- a/src/test/java/io/telicent/jira/sync/client/parser/TestDocParser.java
+++ b/src/test/java/io/telicent/jira/sync/client/parser/TestDocParser.java
@@ -1,0 +1,87 @@
+package io.telicent.jira.sync.client.parser;
+
+import com.atlassian.adf.jackson2.AdfJackson2;
+import com.atlassian.adf.markdown.MarkdownParser;
+import com.atlassian.adf.model.node.Doc;
+import io.telicent.jira.sync.client.generator.DocGenerator;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestDocParser {
+
+    private static final MarkdownParser PARSER = new MarkdownParser();
+    private static final AdfJackson2 JACKSON = new AdfJackson2();
+    private static final DocGenerator DOC_GENERATOR = new DocGenerator();
+    private static final DocParser DOC_PARSER = new DocParser();
+
+    public static Doc fromMarkdown(String markdown) {
+        return PARSER.unmarshall(markdown);
+    }
+
+    public static String toJSON(Doc doc) {
+        return JACKSON.marshall(doc);
+    }
+
+    private void verifyRoundTrip(Doc doc, JSONObject generated) throws JSONException {
+        Doc parsed = DOC_PARSER.parse(generated);
+        Assert.assertEquals(parsed, doc);
+    }
+
+    @Test
+    public void givenSimpleDocument_whenGeneratingJSON_thenRoundTrips() throws JSONException {
+        // Given
+        String markdown = """
+                # A Title
+                
+                Here is some content with an **important** [link](https://example.org)
+                """;
+        Doc doc = fromMarkdown(markdown);
+
+        // When
+        JSONObject json = DOC_GENERATOR.generate(doc);
+
+        // Then
+        verifyRoundTrip(doc, json);
+    }
+
+    @Test
+    public void givenComplexDocument_whenGeneratingJSON_thenRoundTrips() throws JSONException {
+        // Given
+        String markdown = """
+                # A Title
+                
+                Here is some content with an **important** [link](https://example.org)
+                
+                ## Subtitle
+                
+                Here is a list:  
+                
+                - A
+                - B
+                    - C
+                    - D
+                         - E
+                    - F
+                - G
+                
+                ---
+                
+                ### A further subtitle
+                
+                Here's an *ordered* list:
+                
+                1. One
+                2. Two
+              
+                """;
+        Doc doc = fromMarkdown(markdown);
+
+        // When
+        JSONObject json = DOC_GENERATOR.generate(doc);
+
+        // Then
+        verifyRoundTrip(doc, json);
+    }
+}


### PR DESCRIPTION
This PR adds support for syncing GitHub issue comments as JIRA issue comments on the corresponding JIRA issues

Also:

- Now processes GitHub Issues in ascending numeric order
- Now ignores closed GitHub Issues by default
- Can now optionally close the GitHub Issue after sync

# Related Issues and PRs

- This resolves #8 
- This resolves #16 