### PR TITLE
Make JIRA link navigable

### DIFF
--- a/src/main/java/io/telicent/jira/sync/cli/commands/issues/GitHubToJira.java
+++ b/src/main/java/io/telicent/jira/sync/cli/commands/issues/GitHubToJira.java
@@ -222,7 +222,7 @@ public class GitHubToJira extends JiraGitHubSyncCommand {
         if (this.closeAfterSync && issue.getState() == GHIssueState.OPEN) {
             if (!this.dryRun) {
                 GHIssueComment comment = issue.comment(
-                        "This issue was synced to JIRA as " + jiraKey + " and will be tracked and actioned there in future");
+                        GitHubUtils.buildCloseComment(this.jiraOptions.getBaseUrl(), jiraKey));
                 syncOneComment(crossLinks, issue, jiraKey, comment, jiraRestClient.getCommentsClient());
                 issue.close(GHIssueStateReason.COMPLETED);
                 System.out.println("Closed GitHub Issue #" + issue.getNumber());

--- a/src/main/java/io/telicent/jira/sync/cli/options/JiraOptions.java
+++ b/src/main/java/io/telicent/jira/sync/cli/options/JiraOptions.java
@@ -76,4 +76,12 @@ public class JiraOptions {
         }
     }
 
+    /**
+     * Gets the Base URL of the JIRA instance
+     *
+     * @return Base URL
+     */
+    public String getBaseUrl() {
+        return this.jiraUrl;
+    }
 }

--- a/src/main/java/io/telicent/jira/sync/utils/GitHubUtils.java
+++ b/src/main/java/io/telicent/jira/sync/utils/GitHubUtils.java
@@ -1,6 +1,5 @@
 package io.telicent.jira.sync.utils;
 
-import org.jetbrains.annotations.NotNull;
 import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHLabel;
 import org.kohsuke.github.GHUser;
@@ -18,10 +17,9 @@ public class GitHubUtils {
      * @param createdAt When the issue/comment was created
      * @param updatedAt When the issue/comment was last updated
      * @return Preamble
-     * @throws IOException
      */
     public static StringBuilder buildPreamble(GHUser user, Date createdAt, Date updatedAt, String action,
-                                              String originalUrl) throws IOException {
+                                              String originalUrl) {
         StringBuilder commentPreamble = new StringBuilder();
         if (user != null) {
             commentPreamble.append("GitHub User [")
@@ -42,16 +40,34 @@ public class GitHubUtils {
         return commentPreamble;
     }
 
-    private static String getUsername(GHUser user) throws IOException {
-        if (user.getName() != null) {
-            return user.getName();
-        } else if (user.getLogin() != null) {
+    /**
+     * Gets the most human-readable username available for a user
+     *
+     * @param user GitHub User
+     * @return Human-readable username
+     */
+    private static String getUsername(GHUser user)  {
+        try {
+            if (user.getName() != null) {
+                return user.getName();
+            }
+        } catch (IOException e) {
+            // Ignore and fallback to other options
+        }
+
+        if (user.getLogin() != null) {
             return user.getLogin();
         } else {
             return Long.toString(user.getId());
         }
     }
 
+    /**
+     * Translates GitHub Issue labels into JIRA labels (which are simple strings)
+     *
+     * @param issue GitHub Issue
+     * @return JIRA Labels
+     */
     public static Object translateLabels(GHIssue issue) {
         List<String> labels = new ArrayList<>();
         for (GHLabel label : issue.getLabels()) {
@@ -60,7 +76,14 @@ public class GitHubUtils {
         return labels;
     }
 
-    public static @NotNull String buildCloseComment(String jiraBaseUrl, String jiraIssueKey) {
+    /**
+     * Builds a comment message that links to the JIRA issue created for a GitHub issue
+     *
+     * @param jiraBaseUrl  JIRA Base URL
+     * @param jiraIssueKey JIRA Issue Key
+     * @return Comment message as Markdown
+     */
+    public static String buildCloseComment(String jiraBaseUrl, String jiraIssueKey) {
         StringBuilder builder = new StringBuilder();
         builder.append("This issue was synced to JIRA as [")
                .append(jiraIssueKey)

--- a/src/main/java/io/telicent/jira/sync/utils/GitHubUtils.java
+++ b/src/main/java/io/telicent/jira/sync/utils/GitHubUtils.java
@@ -1,5 +1,6 @@
 package io.telicent.jira.sync.utils;
 
+import org.jetbrains.annotations.NotNull;
 import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHLabel;
 import org.kohsuke.github.GHUser;
@@ -57,5 +58,17 @@ public class GitHubUtils {
             labels.add(label.getName());
         }
         return labels;
+    }
+
+    public static @NotNull String buildCloseComment(String jiraBaseUrl, String jiraIssueKey) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("This issue was synced to JIRA as [")
+               .append(jiraIssueKey)
+               .append("](")
+               .append(jiraBaseUrl)
+               .append("/browse/")
+               .append(jiraIssueKey)
+               .append(") and will be tracked and actioned there in future");
+        return builder.toString();
     }
 }


### PR DESCRIPTION
When using `--close-after-sync` the JIRA link injected as a comment will be navigable to the actual JIRA issue