### PR TITLE
Add --extra-labels option to the to-jira command

### DIFF
--- a/src/main/java/io/telicent/jira/sync/cli/JiraSyncCli.java
+++ b/src/main/java/io/telicent/jira/sync/cli/JiraSyncCli.java
@@ -7,6 +7,7 @@ import com.github.rvesse.airline.annotations.help.ExitCodes;
 import com.github.rvesse.airline.parser.ParseResult;
 import com.github.rvesse.airline.parser.errors.ParseException;
 import com.github.rvesse.airline.parser.errors.handlers.CollectAll;
+import com.github.rvesse.airline.parser.options.MaybeListValueOptionParser;
 import io.telicent.jira.sync.cli.commands.*;
 import io.telicent.jira.sync.cli.commands.issues.*;
 
@@ -31,7 +32,11 @@ import io.telicent.jira.sync.cli.commands.issues.*;
             defaultCommand = Help.class
         )
      },
-     parserConfiguration = @Parser(errorHandler = CollectAll.class))
+     parserConfiguration = @Parser(
+             errorHandler = CollectAll.class,
+             defaultParsersFirst = false,
+             optionParsers = { MaybeListValueOptionParser.class }
+     ))
 @ExitCodes(
     codes = { 0, 1, 2, 3 },
     descriptions = {

--- a/src/main/java/io/telicent/jira/sync/cli/commands/issues/GitHubToJira.java
+++ b/src/main/java/io/telicent/jira/sync/cli/commands/issues/GitHubToJira.java
@@ -67,8 +67,11 @@ public class GitHubToJira extends JiraGitHubSyncCommand {
     @Option(name = "--skip-existing", description = "When specified skips sync'ing issues that have already been sync'd to JIRA, this means any changes on the GitHub issue are not reflected in the JIRA but reduces the number of spurious JIRA updates.")
     private boolean skipExisting = false;
 
-    @Option(name = "--dry-run", description = "When specified print what would happen without actually performing the actions i.e. preview what the results of running the command would be")
+    @Option(name = "--dry-run", description = "When specified print what would happen without actually performing the actions i.e. preview what the results of running the command would be.")
     private boolean dryRun = false;
+
+    @Option(name = "--extra-labels", description = "Specifies extra labels that are added to the JIRA issue in addition to the GitHub labels already present on the GitHub issues.")
+    private List<String> extraLabels = new ArrayList<>();
 
     @Override
     public int run() {
@@ -158,7 +161,7 @@ public class GitHubToJira extends JiraGitHubSyncCommand {
                                                                 .setSummary(issue.getTitle())
                                                                 .setFieldInput(new FieldInput(IssueFieldId.LABELS_FIELD,
                                                                                               GitHubUtils.translateLabels(
-                                                                                                      issue)));
+                                                                                                      issue, this.extraLabels)));
         // TODO Copy assignee where relevant
 
         if (StringUtils.isNotBlank(this.jiraRepositoryField)) {

--- a/src/main/java/io/telicent/jira/sync/utils/GitHubUtils.java
+++ b/src/main/java/io/telicent/jira/sync/utils/GitHubUtils.java
@@ -1,5 +1,6 @@
 package io.telicent.jira.sync.utils;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHLabel;
 import org.kohsuke.github.GHUser;
@@ -66,12 +67,16 @@ public class GitHubUtils {
      * Translates GitHub Issue labels into JIRA labels (which are simple strings)
      *
      * @param issue GitHub Issue
+     * @param extraLabels Extra labels to add
      * @return JIRA Labels
      */
-    public static Object translateLabels(GHIssue issue) {
+    public static Object translateLabels(GHIssue issue, List<String> extraLabels) {
         List<String> labels = new ArrayList<>();
         for (GHLabel label : issue.getLabels()) {
             labels.add(label.getName());
+        }
+        if (CollectionUtils.isNotEmpty(extraLabels)) {
+            labels.addAll(extraLabels);
         }
         return labels;
     }


### PR DESCRIPTION
Adds a new option that allows supplying additional labels that should be applied to GitHub issues when sync'ing them over to JIRA