### PR TITLE
Add page consumption to cross-links command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitHub to JIRA Sync
 
+## 0.4.0
+
+- `issues cross-links` keeps searching for issues as long as at least one issue is discovered in the project
+
 ## 0.3.0
 
 - Add new `issues type-mappings` command for previewing how your defined JIRA Issue Mappings will be applied to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.4.0
 
 - `issues cross-links` keeps searching for issues as long as at least one issue is discovered in the project
+- `to-jira` command now takes into account existing labels on the JIRA issue when applying labels from the GitHub 
+  side and ensures any pre-existing labels are preserved
 
 ## 0.3.0
 

--- a/src/main/java/io/telicent/jira/sync/utils/GitHubUtils.java
+++ b/src/main/java/io/telicent/jira/sync/utils/GitHubUtils.java
@@ -71,7 +71,7 @@ public class GitHubUtils {
      * @param extraLabels Extra labels to add
      * @return JIRA Labels
      */
-    public static Object translateLabels(GHIssue issue, List<String> extraLabels) {
+    public static List<String> translateLabels(GHIssue issue, List<String> extraLabels) {
         List<String> labels = new ArrayList<>();
         for (GHLabel label : issue.getLabels()) {
             labels.add(sanitiseForJira(label.getName()));


### PR DESCRIPTION
The` issues cross-links` command previously did not take into account the fact that JQL Search results are paged so would only find the cross links for the next 50 issues (the default page size for the relevant REST API call).  The command now continues to loop making a query to get the next page of issues until there are no further issues.